### PR TITLE
renamed timeuuidl to timeuuid, tested independently against CQL spec 3…

### DIFF
--- a/lib/const.js
+++ b/lib/const.js
@@ -7,7 +7,7 @@ var _s = require('underscore.string');
 function cqlTypes() {
     var types = [
         'ascii', 'bigint', 'blob', 'boolean', 'counter', 'decimal', 'double', 'float',
-        'inet', 'int', 'text', 'timestamp', 'timeuuidl', 'uuid', 'varchar', 'varint'
+        'inet', 'int', 'text', 'timestamp', 'timeuuid', 'uuid', 'varchar', 'varint'
     ];
     return _.object(types, types);
 }

--- a/lib/fluent-cql.js
+++ b/lib/fluent-cql.js
@@ -571,7 +571,7 @@ function FluentCql(validate) {
  * @prop {string} int -         CQL 'int' type.
  * @prop {string} text -        CQL 'text' type.
  * @prop {string} timestamp -   CQL 'timestamp' type.
- * @prop {string} timeuuidl -   CQL 'timeuuidl' type.
+ * @prop {string} timeuuid -    CQL 'timeuuid' type.
  * @prop {string} uuid -        CQL 'uuid' type.
  * @prop {string} varchar -     CQL 'varchar' type.
  * @prop {string} varint -      CQL 'varint' type.

--- a/test/unit/fcql.js
+++ b/test/unit/fcql.js
@@ -8,7 +8,7 @@ describe('fcql', function () {
     it('should contain all 16 CQL types', function () {
         var types = [
             'ascii', 'bigint', 'blob', 'boolean', 'counter', 'decimal', 'double', 'float',
-            'inet', 'int', 'text', 'timestamp', 'timeuuidl', 'uuid', 'varchar', 'varint'
+            'inet', 'int', 'text', 'timestamp', 'timeuuid', 'uuid', 'varchar', 'varint'
         ];
         _.difference(types, _.keys(fcql)).must.be.empty();
     });


### PR DESCRIPTION
….4.2 and 3.3.1
